### PR TITLE
Use {{#if @index}} to determin adding ',' to the consul config

### DIFF
--- a/consul/config/basic_config.json
+++ b/consul/config/basic_config.json
@@ -6,8 +6,8 @@
   "client_addr": "{{cfg.client.bind}}",
   "bootstrap_expect": {{cfg.bootstrap.expect}},
   "server": {{cfg.server.mode}},
-  "start_join": ["127.0.0.1"{{#each svc.members}},"{{sys.ip}}"{{/each}}],
-  "retry_join": ["127.0.0.1"{{#each svc.members}},"{{sys.ip}}"{{/each}}],
+  "start_join": [{{#each svc.members}}{{#if @index}},{{/if}}"{{sys.ip}}"{{/each}}],
+  "retry_join": [{{#each svc.members}}{{#if @index}},{{/if}}"{{sys.ip}}"{{/each}}],
   "ports": {
     "dns": {{cfg.ports.dns}},
     "http": {{cfg.ports.http}},


### PR DESCRIPTION
In a handlebars iteration {{@index}} will contain the index of the array
element currently being pointed to.
The {{#if @index}} conditional will consider 0 to by falsey and thus not add
the ',' on the first iteration. Any other number will be truthy.
See http://handlebarsjs.com/block_helpers.html for more information.

cc @byllc 