### PR TITLE
enable management plugin, create a new user with management and admin…

### DIFF
--- a/rabbitmq/config/rabbitmq.config
+++ b/rabbitmq/config/rabbitmq.config
@@ -11,6 +11,7 @@
     {default_vhost,       <<"{{cfg.rabbitmq.default_vhost}}">>},
     {default_user,        <<"{{cfg.rabbitmq.default_user}}">>},
     {default_pass,        <<"{{cfg.rabbitmq.default_pass}}">>},
+    {default_user_tags,   [{{#each cfg.rabbitmq.default_user_tags}}{{#if @index}}, {{/if}}{{this}}{{/each}}]},
     {default_permissions, [<<".*">>, <<".*">>, <<".*">>]}
   ]}
 ].

--- a/rabbitmq/default.toml
+++ b/rabbitmq/default.toml
@@ -10,10 +10,13 @@ listen_port=5672
 default_vhost="/"
 
 # User name to create when RabbitMQ creates a new database from scratch.
-default_user="guest"
+default_user="admin"
 
 # Password for the default user.
-default_pass="guest"
+default_pass="admin"
+
+# give our default user the proper permissions
+default_user_tags = ["administrator", "management"]
 
 cluster_with=""
 name="rabbit"
@@ -21,7 +24,7 @@ name="rabbit"
 [rabbitmq.management]
 
 # Whether to enable the rabbitmq management plugin.
-enabled=false
+enabled=true
 
 [erlang]
 cookie="Gm0+QGpGcsEcxjJPEBY/Tg=="


### PR DESCRIPTION
To log into the management plugin you need the `management` tag set to that user.

If you are not directly on the box that is running the management plugin the `guest` user is not allowed to login (the host needs to be localhost).